### PR TITLE
Fix #10 caused by unintentional variable shadowing 

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -61,16 +61,12 @@ pub fn ansi_to_text<'t, B: IntoIterator<Item = u8>>(bytes: B) -> Result<Text<'t>
                 && !line_buffer.is_empty()
                 && style_stack.last() != Some(&style)
             {
-                let style = match style_stack.pop() {
-                    Some(style) => style,
-                    None => return Err(Error::StackEmpty),
-                };
                 span_buffer.push(Span::styled(
                     #[cfg(feature = "simd")]
                     from_utf8(&line_buffer)?.to_owned(),
                     #[cfg(not(feature = "simd"))]
                     String::from_utf8(line_buffer.clone())?,
-                    style,
+                    style_stack.pop().ok_or(Error::StackEmpty)?,
                 ));
                 line_buffer.clear();
                 style_stack.push(style);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,7 +20,7 @@ fn test_generic() {
     let string = "\x1b[33mYellow\x1b[31mRed\x1b[32mGreen\x1b[0m";
     println!("{:?}\n\n", string);
     // ansi_to_text(string.bytes()).unwrap();
-    println!("{:#?}",ansi_to_text(string.bytes()));
+    println!("{:#?}", ansi_to_text(string.bytes()));
 }
 
 #[test]
@@ -105,5 +105,5 @@ fn test_command() {
 fn test_reset() {
     let string = "\x1b[33mA\x1b[0mB";
     println!("{:?}\n\n", string);
-    println!("{:#?}",ansi_to_text(string.bytes()));
+    println!("{:#?}", ansi_to_text(string.bytes()));
 }


### PR DESCRIPTION
~I'm not sure what's going on, but it seems to fix a few things.~
The variable name style was shadowing another variable with a similar name, outside the scope.

There are still some issues, but let's do one at a time.