### PR TITLE
Properly reset styles

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -96,8 +96,13 @@ fn spans(style: Style) -> impl Fn(&[u8]) -> IResult<&[u8], (Spans<'static>, Styl
         let mut spans = Vec::new();
         let mut last = style;
         while let Ok((s, span)) = span(last)(text) {
+            if span.style == Style::default() && span.content.is_empty() {
+                // Reset styles
+                last = Style::default();
+            } else {
+                last = last.patch(span.style);
+            }
             // Don't include empty spans but keep changing the style
-            last = last.patch(span.style);
             if spans.is_empty() || span.content != "" {
                 spans.push(span);
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,7 +61,7 @@ impl From<AnsiStates> for tui::style::Style {
                 }
                 AnsiCode::SetBackgroundColor => {
                     if let Some(color) = item.color {
-                        style = style.fg(color)
+                        style = style.bg(color)
                     }
                 }
                 AnsiCode::ForegroundColor(color) => style = style.fg(color),


### PR DESCRIPTION
There's a problem that prevents some specific styles from being reset with `\x1b[0m`. The problem is with `Style::patch(...)`, but this PR should fix it.

## Recreating
```rust
let contents = "\x1b[1mText\x1b[0m\x1b[36mText2\x1b[0m";
dbg!(contents.into_text().unwrap());
```

### Expected
```
Text {
    lines: [
        Spans(
            [
                Span {
                    content: "Text",
                    style: Style {
                        fg: None,
                        bg: None,
                        add_modifier: BOLD,
                        sub_modifier: (empty),
                    },
                },
                Span {
                    content: "Text2",
                    style: Style {
                        fg: Some(
                            Cyan,
                        ),
                        bg: None,
                        add_modifier: (empty),
                        sub_modifier: (empty),
                    },
                },
            ],
        ),
    ],
}
```

### Got
```
Text {
    lines: [
        Spans(
            [
                Span {
                    content: "Text",
                    style: Style {
                        fg: None,
                        bg: None,
                        add_modifier: BOLD,
                        sub_modifier: (empty),
                    },
                },
                Span {
                    content: "Text2",
                    style: Style {
                        fg: Some(
                            Cyan,
                        ),
                        bg: None,
                        add_modifier: BOLD,
                        sub_modifier: (empty),
                    },
                },
            ],
        ),
    ],
}
```