### PR TITLE
Update to Ratatui 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/uttarayan21/ansi-to-tui"
 [dependencies]
 nom = "7.1"
 simdutf8 = { version = "0.1", optional = true }
-tui = { version = "0.*", default-features = false, package = "ratatui" }
+tui = { version = "0.21", default-features = false, package = "ratatui" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@
 use ansi_to_tui::IntoText;
 use tui::{
     style::{Color, Style},
-    text::{Span, Spans, Text},
+    text::{Line, Span, Text},
 };
 
 // #[test]
@@ -39,20 +39,20 @@ fn test_unicode() {
     // these are 8 byte unicode charachters
     // first 4 bytes are for the unicode and the last 4 bytes are for the color / variant
     let bytes = "AAA🅱️🅱️🅱️".as_bytes().to_vec();
-    let output = some_text("AAA🅱️🅱️🅱️");
+    let output = Ok(Text::raw("AAA🅱️🅱️🅱️"));
     assert_eq!(bytes.into_text(), output);
 }
 
 #[test]
 fn test_ascii_rgb() {
     let bytes: Vec<u8> = b"\x1b[38;2;100;100;100mAAABBB".to_vec();
-    let output = Ok(Text::from(Spans::from(Span::styled(
+    let output = Ok(Text::styled(
         "AAABBB",
         Style {
             fg: Some(Color::Rgb(100, 100, 100)),
             ..Default::default()
         },
-    ))));
+    ));
     assert_eq!(bytes.into_text(), output);
 }
 
@@ -66,14 +66,14 @@ fn test_ascii_rgb() {
 fn test_ascii_newlines() {
     let bytes = "LINE_1\n\n\n\n\n\n\nLINE_8".as_bytes().to_vec();
     let output = Ok(Text::from(vec![
-        Spans::from(Span::raw("LINE_1")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("")),
-        Spans::from(Span::raw("LINE_8")),
+        Line::from("LINE_1"),
+        Line::from(""),
+        Line::from(""),
+        Line::from(""),
+        Line::from(""),
+        Line::from(""),
+        Line::from(""),
+        Line::from("LINE_8"),
     ]));
 
     // println!("{:#?}", bytes.into_text());
@@ -120,72 +120,50 @@ fn test_ascii_newlines() {
 #[test]
 fn test_reset() {
     let string = "\x1b[33mA\x1b[0mB";
-    let output = Ok(Text {
-        lines: vec![Spans(vec![
-            Span::styled(
-                "A",
-                Style {
-                    fg: Some(Color::Yellow),
-                    ..Default::default()
-                },
-            ),
-            Span::styled(
-                "B",
-                Style {
-                    ..Default::default()
-                },
-            ),
-        ])],
-    });
+    let output = Ok(Text::from(Line::from(vec![
+        Span::styled("A", Style::default().fg(Color::Yellow)),
+        Span::raw("B"),
+    ])));
     assert_eq!(string.into_text(), output);
 }
 
 #[test]
 fn test_screen_modes() {
     let bytes: Vec<u8> = b"\x1b[?25hAAABBB".to_vec();
-    let output = Ok(Text::from(Spans::from(Span::styled(
+    let output = Ok(Text::styled(
         "AAABBB", // or "AAABBB"
         Style::default(),
-    ))));
+    ));
     assert_eq!(bytes.into_text(), output);
 }
 
 #[test]
 fn test_cursor_shape_and_color() {
     let bytes: Vec<u8> = b"\x1b[4 q\x1b]12;#fab1ed\x07".to_vec();
-    let output = Ok(Text::from(Spans::from(Span::styled("", Style::default()))));
+    let output = Ok(Text::raw(""));
     assert_eq!(bytes.into_text(), output);
 }
 
 #[test]
 fn test_malformed_simple() {
     let bytes: Vec<u8> = b"\x1b[".to_vec();
-    let output = Ok(Text::from(Spans::from(Span::styled("", Style::default()))));
+    let output = Ok(Text::raw(""));
     assert_eq!(bytes.into_text(), output);
 }
 
 #[test]
 fn test_malformed_complex() {
     let bytes: Vec<u8> = b"\x1b\x1b[0\x1b[m\x1b".to_vec();
-    let output = Ok(Text::from(Spans::from(Span::styled("", Style::default()))));
+    let output = Ok(Text::raw(""));
     assert_eq!(bytes.into_text(), output);
-}
-
-fn some_text(s: &'static str) -> Result<Text<'static>, ansi_to_tui::Error> {
-    Ok(Text {
-        lines: vec![Spans(vec![Span {
-            content: s.into(),
-            style: Default::default(),
-        }])],
-    })
 }
 
 #[test]
 fn empty_span() {
     let bytes: Vec<u8> = b"\x1b[33m\x1b[31m\x1b[32mHello\x1b[0mWorld".to_vec();
-    let output = Ok(Text::from(Spans::from(vec![
-        Span::styled("", Style::default().fg(Color::Yellow)), // Not sure whether to keep this or
-                                                              // remove it somehow
+    let output = Ok(Text::from(Line::from(vec![
+        // Not sure whether to keep this empty span or remove it somehow
+        Span::styled("", Style::default().fg(Color::Yellow)),
         Span::styled("Hello", Style::default().fg(Color::Green)),
         Span::styled("World", Style::default()),
     ])));


### PR DESCRIPTION
Cargo.toml is updated to specify 0.21 rather than 0.* as 0.21 deprecates
the `Spans` type and replaces it with `Line`. This is generally a good
thing as it makes the code more readable and easier to use.

A bunch of tests are updated to use the new `Line` type and are
simplified to use the Text::raw / Text::styled functions rather than
constructing the `Spans` type directly.