### PR TITLE
Fix style resets

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,7 @@ impl From<AnsiStates> for tui::style::Style {
         let mut style = states.style;
         for item in states.items {
             match item.code {
-                AnsiCode::Reset => style = Style::default(),
+                AnsiCode::Reset => style = Style::reset(),
                 AnsiCode::Bold => style = style.add_modifier(Modifier::BOLD),
                 AnsiCode::Faint => style = style.add_modifier(Modifier::DIM),
                 AnsiCode::Italic => style = style.add_modifier(Modifier::ITALIC),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 // use ansi_to_tui::{ansi_to_text, ansi_to_text_override_style};
 use ansi_to_tui::IntoText;
+use tui::style::Stylize;
 use tui::{
     style::{Color, Style},
     text::{Line, Span, Text},
@@ -119,7 +120,7 @@ fn test_reset() {
     let string = "\x1b[33mA\x1b[0mB";
     let output = Ok(Text::from(Line::from(vec![
         Span::styled("A", Style::default().fg(Color::Yellow)),
-        Span::raw("B"),
+        Span::styled("B", Style::reset()),
     ])));
     assert_eq!(string.into_text(), output);
 }
@@ -162,8 +163,33 @@ fn empty_span() {
         // Not sure whether to keep this empty span or remove it somehow
         Span::styled("", Style::default().fg(Color::Yellow)),
         Span::styled("Hello", Style::default().fg(Color::Green)),
-        Span::styled("World", Style::default()),
+        Span::styled("World", Style::reset()),
     ])));
+    assert_eq!(bytes.into_text(), output);
+}
+
+#[test]
+fn test_color_and_style_reset() {
+    let bytes: Vec<u8> = String::from(
+        "\u{1b}[32m* \u{1b}[0mRunning before-startup command \u{1b}[1mcommand\u{1b}[0m=make my-simple-package.cabal\n\
+        \u{1b}[32m* \u{1b}[0m$ make my-simple-package.cabal\n\
+        Build profile: -w ghc-9.0.2 -O1\n").into_bytes();
+    let output = Ok(Text::from(vec![
+        Line::from(vec![
+            Span::styled("* ", Style::default().fg(Color::Green)),
+            Span::styled("Running before-startup command ", Style::reset()),
+            Span::styled("command", Style::reset().bold()),
+            Span::styled("=make my-simple-package.cabal", Style::reset()),
+        ]),
+        Line::from(vec![
+            Span::styled("* ", Style::reset().fg(Color::Green)),
+            Span::styled("$ make my-simple-package.cabal", Style::reset()),
+        ]),
+        Line::from(vec![Span::styled(
+            "Build profile: -w ghc-9.0.2 -O1",
+            Style::reset(),
+        )]),
+    ]));
     assert_eq!(bytes.into_text(), output);
 }
 
@@ -262,7 +288,7 @@ mod zero_copy {
         let string = "\x1b[33mA\x1b[0mB";
         let output = Ok(Text::from(Line::from(vec![
             Span::styled("A", Style::default().fg(Color::Yellow)),
-            Span::raw("B"),
+            Span::styled("B", Style::reset()),
         ])));
         assert_eq!(string.to_text(), output);
     }
@@ -305,8 +331,33 @@ mod zero_copy {
             // Not sure whether to keep this empty span or remove it somehow
             Span::styled("", Style::default().fg(Color::Yellow)),
             Span::styled("Hello", Style::default().fg(Color::Green)),
-            Span::styled("World", Style::default()),
+            Span::styled("World", Style::reset()),
         ])));
         assert_eq!(bytes.to_text(), output);
+    }
+
+    #[test]
+    fn test_color_and_style_reset() {
+        let bytes: Vec<u8> = String::from(
+            "\u{1b}[32m* \u{1b}[0mRunning before-startup command \u{1b}[1mcommand\u{1b}[0m=make my-simple-package.cabal\n\
+            \u{1b}[32m* \u{1b}[0m$ make my-simple-package.cabal\n\
+            Build profile: -w ghc-9.0.2 -O1\n").into_bytes();
+        let output = Ok(Text::from(vec![
+            Line::from(vec![
+                Span::styled("* ", Style::default().fg(Color::Green)),
+                Span::styled("Running before-startup command ", Style::reset()),
+                Span::styled("command", Style::reset().bold()),
+                Span::styled("=make my-simple-package.cabal", Style::reset()),
+            ]),
+            Line::from(vec![
+                Span::styled("* ", Style::reset().fg(Color::Green)),
+                Span::styled("$ make my-simple-package.cabal", Style::reset()),
+            ]),
+            Line::from(vec![Span::styled(
+                "Build profile: -w ghc-9.0.2 -O1",
+                Style::reset(),
+            )]),
+        ]));
+        assert_eq!(bytes.into_text(), output);
     }
 }


### PR DESCRIPTION
`ansi-to-tui` translates `\x1b[0m` as `Style::default()` and then updates the "running style" with `style.patch`, but `style.patch(Style::default()) == style`, so no change is made. This leads to subtle issues where colors and style modifiers are erroneously reintroduced after reset sequences.

This is simple to fix by translating `\x1b[0m` as `Style::reset()` instead.