### PR TITLE
fix: pin ratatui to less than 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/uttarayan21/ansi-to-tui"
 
 [dependencies]
 nom = "7.1"
-tui = { version = "0.*,>=0.21", default-features = false, package = "ratatui" }
+tui = { version = "0.*,>=0.21,<0.27.0", default-features = false, package = "ratatui" }
 thiserror = "1.0"
 simdutf8 = { version = "0.1", optional = true }
 smallvec = { version = "1.10.0", features = ["const_generics"] }


### PR DESCRIPTION
- ratatui 0.27.0 introduces a number of breaking changes
- while libraries are updating to v0.27 having an open upper bound is awkward as consumer crates can require both, causing compilation failures where the lock file isn't being followed
- proposal that we pin a patch to <0.27.0 for compatibility, then relax dependency as part of upgrade to 0.27