### PR TITLE
fix command 'cargo test --no-default-features'

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -269,9 +269,12 @@ fn test_faint_reset_sequences() {
 #[track_caller]
 pub fn test_both(bytes: impl AsRef<[u8]>, other: Text) {
     let bytes = bytes.as_ref();
+    #[cfg(feature = "zero-copy")]
     let zero_copy = bytes.to_text().unwrap();
     let owned = bytes.into_text().unwrap();
+    #[cfg(feature = "zero-copy")]
     assert_eq!(zero_copy, owned, "zero-copy and owned version of the methods have diverged this is for sure a bug in the library");
     assert_eq!(owned, other, "owned and other have diverged this migh be due to a bug in the library or maybe an update to the ratatui crate");
+    #[cfg(feature = "zero-copy")]
     assert_eq!(zero_copy, other);
 }


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/ansi-to-tui/debian/patches/fix-tests-no-default-features.patch