### PR TITLE
ci: unrelease 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.1](https://github.com/ratatui/ansi-to-tui/compare/v7.0.0...v7.0.1) - 2025-04-26
-
-### Other
-
-- indicate in README that into_text is fallible ([#62](https://github.com/ratatui/ansi-to-tui/pull/62))
-- Fix reset for underline/blink/italic/hidden ([#57](https://github.com/ratatui/ansi-to-tui/pull/57))
-
 ## [7.0.0](https://github.com/ratatui/ansi-to-tui/compare/v6.0.1...v7.0.0) - 2024-10-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-to-tui"
-version = "7.0.1"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ansi-to-tui"
-version = "7.0.1"
+version = "7.0.0"
 authors = ["Uttarayan Mondal <email@uttarayan.me>"]
 edition = "2018"
 description = "A library to convert ansi color coded text into ratatui::text::Text type from ratatui library"


### PR DESCRIPTION
7.0.1 failed to actually be released by Release-plz properly, so instead this will be released as 8.0.0-beta.0

This helps the release-plz CI process properly sort out the right version.