### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   push:
@@ -10,11 +11,11 @@ on:
       - main
 
 jobs:
-
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'ratatui' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,12 +29,12 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'ratatui' }}
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
@@ -50,4 +51,3 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Also, don't run on forks

- https://crates.io/docs/trusted-publishing
- https://release-plz.dev/docs/github/quickstart#2-set-the-cargo_registry_token-secret