### PR TITLE
chore: update ratatui-core to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0-beta.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3634611dccc2110ab05a64fec77d26c5f0e0cb0c0bfecb291d9a15841aae91"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/uttarayan21/ansi-to-tui"
 
 [dependencies]
 nom = "8"
-ratatui-core = { version = "0.1.0-beta", default-features = false }
+ratatui-core = { version = "0.1.0", default-features = false }
 simdutf8 = { version = "0.1", optional = true }
 smallvec = { version = "1", features = ["const_generics"] }
 thiserror = "2"


### PR DESCRIPTION
Move off the beta release to align with ratatui 0.30 stable.