### PR TITLE
docs: polish Ratatui docs and metadata

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+config:
+  MD013:
+    line_length: 100
+
+globs:
+  - "**/*.md"
+
+ignores:
+  - "CHANGELOG.md"
+  - "target/**"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,14 @@ name = "ansi-to-tui"
 version = "8.0.0"
 authors = ["Uttarayan Mondal <email@uttarayan.me>"]
 edition = "2024"
-description = "A library to convert ansi color coded text into ratatui::text::Text type from ratatui library"
-keywords = ["ansi", "ascii", "tui", "parser"]
+rust-version = "1.85"
+description = "Convert ANSI color and style codes into Ratatui Text"
+keywords = ["ansi", "ascii", "ratatui", "parser", "style"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/uttarayan21/ansi-to-tui"
+repository = "https://github.com/ratatui/ansi-to-tui"
+documentation = "https://docs.rs/ansi-to-tui"
+homepage = "https://ratatui.rs"
 
 [dependencies]
 nom = "8"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # ansi-to-tui
 
-![drone build](https://img.shields.io/drone/build/uttarayan21/ansi-to-tui?server=https%3A%2F%2Fdrone.uttarayan.me)
-[![github build](https://github.com/uttarayan21/ansi-to-tui/actions/workflows/build.yaml/badge.svg)][ansi-to-tui]
-[![downloads](https://img.shields.io/crates/d/ansi-to-tui)](https://crates.io/crates/ansi-to-tui)
+[![Crate Badge]][Crate] [![Repo Badge]][Repo]  \
+[![Docs Badge]][Docs] [![License Badge]][License]  \
+[![CI Badge]][CI] [![Codecov Badge]][Codecov]
 
-A nom parser to parse text with ANSI color codes and turn them into [`ratatui::text::Text`][Text].
+Convert ANSI color and style codes into Ratatui [`Text`][Text].
 
-For people still using [tui-rs](docs.rs/tui) use version `v2.*` for people migrating to
-[ratatui](docs.rs/ratatui) use version `v3.*`+. I recommend switching over to ratatui since tui-rs
-is currently unmaintained.
+This crate parses bytes containing ANSI SGR escape sequences (like `\x1b[31m`).
+It produces a Ratatui [`Text`][Text] with equivalent foreground/background [`Color`][Color] and
+[`Modifier`][Modifier] settings via [`Style`][Style].
 
-| Color  | Supported | Examples                 |
-| ------ | :-------: | ------------------------ |
-| 24 bit |     ✓     | `\x1b[38;2;<R>;<G>;<B>m` |
-| 8 bit  |     ✓     | `\x1b[38;5;<N>m`         |
-| 4 bit  |     ✓     | `\x1b[30..37;40..47m`    |
+Unknown or malformed escape sequences are ignored so you can feed it real terminal output without
+having to pre-clean it.
+
+| Color Mode                  | Supported | SGR Example              | Ratatui `Color` Example |
+| --------------------------- | :-------: | ------------------------ | ----------------------- |
+| Named (3/4-bit, 8/16-color) |     ✓     | `\x1b[30..37;40..47m`    | `Color::Blue`           |
+| Indexed (8-bit, 256-color)  |     ✓     | `\x1b[38;5;<N>m`         | `Color::Indexed(1)`     |
+| Truecolor (24-bit RGB)      |     ✓     | `\x1b[38;2;<R>;<G>;<B>m` | `Color::Rgb(255, 0, 0)` |
 
 ## Example
 
@@ -24,5 +27,19 @@ let buffer = std::fs::read("ascii/text.ascii")?;
 let output = buffer.into_text()?;
 ```
 
-[Text]: https://docs.rs/ratatui/latest/ratatui/text/struct.Text.html
-[ansi-to-tui]: https://github.com/uttarayan21/ansi-to-tui
+[Text]: https://docs.rs/ratatui-core/latest/ratatui_core/text/struct.Text.html
+[Color]: https://docs.rs/ratatui-core/latest/ratatui_core/style/enum.Color.html
+[Style]: https://docs.rs/ratatui-core/latest/ratatui_core/style/struct.Style.html
+[Modifier]: https://docs.rs/ratatui-core/latest/ratatui_core/style/struct.Modifier.html
+[Crate Badge]: https://img.shields.io/crates/v/ansi-to-tui?logo=rust
+[Crate]: https://crates.io/crates/ansi-to-tui
+[Repo Badge]: https://img.shields.io/badge/repo-ansi--to--tui-blue?logo=github
+[Repo]: https://github.com/ratatui/ansi-to-tui
+[Docs Badge]: https://img.shields.io/badge/docs-ansi--to--tui-blue?logo=rust
+[Docs]: https://docs.rs/ansi-to-tui
+[License Badge]: https://img.shields.io/crates/l/ansi-to-tui
+[License]: LICENSE
+[CI Badge]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yaml/badge.svg
+[CI]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yaml
+[Codecov Badge]: https://codecov.io/gh/ratatui/ansi-to-tui/branch/master/graph/badge.svg
+[Codecov]: https://codecov.io/gh/ratatui/ansi-to-tui

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,20 @@
-/// This enum stores the error types
+/// Errors returned by this crate.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum Error {
-    /// Stack is empty (should never happen)
-    #[error("Internal error: stack is empty")]
+    /// Parsing failed.
+    ///
+    /// This is currently a formatted representation of a `nom` parse error.
+    #[error("Parse error: {0}")]
     NomError(String),
 
-    /// Error parsing the input as utf-8
+    /// The input contains invalid UTF-8.
     #[cfg(feature = "simd")]
-    /// Cannot determine the foreground or background
-    #[error("{0:?}")]
+    #[error(transparent)]
     Utf8Error(#[from] simdutf8::basic::Utf8Error),
 
+    /// The input contains invalid UTF-8.
     #[cfg(not(feature = "simd"))]
-    /// Cannot determine the foreground or background
-    #[error("{0:?}")]
+    #[error(transparent)]
     Utf8Error(#[from] std::string::FromUtf8Error),
 }
 


### PR DESCRIPTION
Update crate and README docs to focus on Ratatui.

- Remove stale tui-rs/Drone references
- Switch links to ratatui-core types
- Add an SGR→Ratatui color mapping table (named/indexed/truecolor) with foreground vs background examples
- Improve Rustdoc for `IntoText` (examples + zero-copy lifetime semantics)
- Improve docs for `Error`
- Add markdownlint-cli2 config (100-char lines, ignore `target/`)
- Refresh Cargo.toml metadata (MSRV, repo/docs/homepage, keywords)