### PR TITLE
ci: add cargo workflow alongside Nix

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,3 @@
+[yanked]
+enabled = false
+update_index = false

--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -1,10 +1,14 @@
-name: build
+name: build-nix
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,28 +39,3 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build -L '.#${{ matrix.attr }}'
-
-  codecov:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: "write"
-      contents: "read"
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-
-    - name: Run codecov
-      run: nix build .#checks.x86_64-linux.ansi-to-tui-llvm-coverage
-
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
-      with:
-        flags: unittests
-        name: codecov-ansi-to-tui
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./result
-        verbose: true
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,110 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  toml-fmt:
+    name: toml-fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+      - run: taplo fmt --check
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  nextest:
+    name: nextest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - run: cargo nextest run --all-features
+      - run: cargo nextest run --no-default-features
+
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps
+
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: stable
+
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'ratatui' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v4.0.1
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for contributing!
+
+## CI Overview
+
+This repo has two CI workflows:
+
+- `build.yml` (Cargo): contributor-friendly checks using standard Rust tooling.
+- `build-nix.yml` (Nix): reproducible, flake-defined checks executed via `nix build`.
+
+The Nix workflow generates its job matrix by evaluating `.#githubActions.matrix`, so the checks it
+runs in CI are the same ones you can run locally with Nix.
+
+### Why Nix?
+
+Using Nix adds some complexity, but it also buys a few things that are otherwise hard to keep
+reliable over time:
+
+- A pinned Rust toolchain (aligned with the crate MSRV) and pinned tool versions via `flake.lock`.
+- A single source of truth for the check list (the flake), used both locally and in CI.
+- Reproducible builds across machines/CI runners, which helps avoid "works on my machine" issues.
+
+The Cargo workflow exists so contributors can run the same checks without needing to learn Nix.
+
+## Local Development (Cargo)
+
+These commands match what `build.yml` runs:
+
+```bash
+taplo fmt --check
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo nextest run --all-features
+cargo nextest run --no-default-features
+cargo doc --no-deps
+```
+
+If you don't have `cargo-nextest` installed, you can use `cargo test` instead:
+
+```bash
+cargo test --all-features
+cargo test --no-default-features
+```
+
+### Dependency and License Checks
+
+If you have these tools installed locally, you can run:
+
+```bash
+cargo deny check
+cargo audit
+```
+
+## Local Development (Nix)
+
+If you use Nix, the flake exposes the same checks CI runs. Typical invocations:
+
+```bash
+nix build -L .#checks.x86_64-linux.ansi-to-tui-fmt
+nix build -L .#checks.x86_64-linux.ansi-to-tui-clippy
+nix build -L .#checks.x86_64-linux.ansi-to-tui-nextest
+```
+
+To see the matrix that CI evaluates:
+
+```bash
+nix eval --json .#githubActions.matrix
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +90,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -157,10 +176,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -169,6 +189,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -180,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -246,6 +267,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "foldhash"
@@ -341,6 +368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+
+[[package]]
 name = "lru"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +417,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "plotters"
@@ -575,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +798,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +821,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ansi-to-tui"
 version = "8.0.0"
 authors = ["Uttarayan Mondal <email@uttarayan.me>"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 description = "Convert ANSI color and style codes into Ratatui Text"
 keywords = ["ansi", "ascii", "ratatui", "parser", "style"]
 license = "MIT"
@@ -21,7 +21,7 @@ thiserror = "2"
 
 [dev-dependencies]
 anyhow = "1"
-criterion = "0.7"
+criterion = "0.8"
 eyre = "0.6"
 pretty_assertions = "1.4"
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ let buffer = std::fs::read("ascii/text.ascii")?;
 let output = buffer.into_text()?;
 ```
 
+Contributing and CI details are in [`CONTRIBUTING.md`][Contributing].
+
 [Text]: https://docs.rs/ratatui-core/latest/ratatui_core/text/struct.Text.html
 [Color]: https://docs.rs/ratatui-core/latest/ratatui_core/style/enum.Color.html
 [Style]: https://docs.rs/ratatui-core/latest/ratatui_core/style/struct.Style.html
@@ -37,9 +39,10 @@ let output = buffer.into_text()?;
 [Repo]: https://github.com/ratatui/ansi-to-tui
 [Docs Badge]: https://img.shields.io/badge/docs-ansi--to--tui-blue?logo=rust
 [Docs]: https://docs.rs/ansi-to-tui
+[Contributing]: CONTRIBUTING.md
 [License Badge]: https://img.shields.io/crates/l/ansi-to-tui
 [License]: LICENSE
-[CI Badge]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yaml/badge.svg
-[CI]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yaml
-[Codecov Badge]: https://codecov.io/gh/ratatui/ansi-to-tui/branch/master/graph/badge.svg
+[CI Badge]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yml/badge.svg
+[CI]: https://github.com/ratatui/ansi-to-tui/actions/workflows/build.yml
+[Codecov Badge]: https://codecov.io/gh/ratatui/ansi-to-tui/branch/main/graph/badge.svg
 [Codecov]: https://codecov.io/gh/ratatui/ansi-to-tui

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,5 +1,5 @@
 pub use ansi_to_tui::IntoText;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/deny.toml
+++ b/deny.toml
@@ -88,7 +88,7 @@ ignore = [
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016", "Zlib"]
+allow = ["MIT", "Apache-2.0", "Unicode-3.0", "Unicode-DFS-2016", "Zlib"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -196,8 +196,8 @@ deny = [
 skip = [
 
   #"ansi_term@0.11.0",
-  { crate = "unicode-width@0.1", reason = "Ratatui depends on unicode-truncate which depends on this" },
-  { crate = "unicode-width@0.2", reason = "Ratatui depends on unicode-width directly" },
+  { crate = "itertools@0.13", reason = "Pulled in via ratatui-core -> unicode-truncate (and criterion dev-dep)" },
+  { crate = "itertools@0.14", reason = "Pulled in via ratatui-core direct dependency" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/flake.lock
+++ b/flake.lock
@@ -71,16 +71,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1767325753,
+        "narHash": "sha256-yA/CuWyqm+AQo2ivGy6PlYrjZBQm7jfbe461+4HF2fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "64049ca74d63e971b627b5f3178d95642e61cedd",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725935143,
-        "narHash": "sha256-mVtTVQMlXkydSXVwFClE0ckxHrOQ9nb2DrCjNwW5pUE=",
+        "lastModified": 1767495280,
+        "narHash": "sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c3c175c74cd0e8c2c40a0e22bc6e3005c4d28d64",
+        "rev": "cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A simple rust flake using rust-overlay and craneLib";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
     nix-github-actions = {
@@ -39,11 +39,13 @@
         };
         inherit (pkgs) lib;
 
-        stableToolchain = pkgs.rust-bin.stable.latest.default;
-        stableToolchainWithLLvmTools = pkgs.rust-bin.stable.latest.default.override {
+        # Keep the Nix toolchain aligned with the crate's MSRV and edition.
+        rustVersion = "1.86.0";
+        stableToolchain = pkgs.rust-bin.stable."${rustVersion}".default;
+        stableToolchainWithLLvmTools = pkgs.rust-bin.stable."${rustVersion}".default.override {
           extensions = ["rust-src" "llvm-tools"];
         };
-        stableToolchainWithRustAnalyzer = pkgs.rust-bin.stable.latest.default.override {
+        stableToolchainWithRustAnalyzer = pkgs.rust-bin.stable."${rustVersion}".default.override {
           extensions = ["rust-src" "rust-analyzer"];
         };
         craneLib = (crane.mkLib pkgs).overrideToolchain stableToolchain;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,12 @@
 use crate::code::AnsiCode;
 use nom::{
+    AsChar, IResult, Parser,
     branch::alt,
     bytes::complete::*,
     character::complete::*,
     combinator::{map_res, opt},
     multi::*,
     sequence::{delimited, preceded},
-    AsChar, IResult, Parser,
 };
 use ratatui_core::{
     style::{Color, Modifier, Style, Stylize},
@@ -215,6 +215,7 @@ fn span_fast(last: Style) -> impl Fn(&[u8]) -> IResult<&[u8], Span<'_>, nom::err
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn style(
     style: Style,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], Option<Style>, nom::error::Error<&[u8]>> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -272,8 +272,14 @@ pub fn test_both(bytes: impl AsRef<[u8]>, other: Text) {
     let zero_copy = bytes.to_text().unwrap();
     let owned = bytes.into_text().unwrap();
     #[cfg(feature = "zero-copy")]
-    assert_eq!(zero_copy, owned, "zero-copy and owned version of the methods have diverged this is for sure a bug in the library");
-    assert_eq!(owned, other, "owned and other have diverged this migh be due to a bug in the library or maybe an update to the ratatui crate");
+    assert_eq!(
+        zero_copy, owned,
+        "zero-copy and owned version of the methods have diverged this is for sure a bug in the library"
+    );
+    assert_eq!(
+        owned, other,
+        "owned and other have diverged this migh be due to a bug in the library or maybe an update to the ratatui crate"
+    );
     #[cfg(feature = "zero-copy")]
     assert_eq!(zero_copy, other);
 }


### PR DESCRIPTION
## Summary

Add a Cargo-based CI workflow alongside the existing Nix-based workflow, and move CI/contributing
notes into `CONTRIBUTING.md` so non-Nix contributors can run the same checks with standard `cargo`
commands.

This also bumps MSRV to Rust 1.86 for compatibility with `ratatui-core`.

## Why

- Nix CI is great for reproducibility, but it can be a barrier for contributors who just want to
  run standard Rust tooling.
- `ratatui-core` now requires Rust 1.86, so the crate MSRV and Nix toolchain need to match.

## What Changed

- Add `.github/workflows/build.yml` (Cargo CI) running: taplo fmt, rustfmt, clippy, nextest (all
  features + no default features), docs, cargo-deny, cargo-audit, and Codecov (push-only in
  `ratatui/*`).
- Move the Nix workflow to `.github/workflows/build-nix.yml`:
  - Generate the job matrix from `.#githubActions.matrix` (flake is the source of truth).
  - Add concurrency cancellation to stop in-flight runs on PR updates.
  - Drop the separate Nix Codecov job (coverage is handled by the Cargo workflow).
- Add `CONTRIBUTING.md` documenting both Cargo and Nix workflows (and why Nix is still used).
- Bump MSRV to Rust 1.86 and align the Nix toolchain pin.
- Pin nixpkgs to `nixos-25.11` so Nix picks up `cargo-deny`/`cargo-audit` versions that understand
  edition 2024 and `Cargo.lock` v4.
- Add `.cargo/audit.toml` to disable yanked checks in sandboxed Nix builds (no crates.io index).
- Cargo policy/tooling updates:
  - Bump `criterion` to `0.8`.
  - `cargo-deny`: allow `Unicode-3.0` (for `unicode-ident`) and skip known duplicate `itertools`
    versions with provenance notes.
- Minor code hygiene: allow `clippy::type_complexity` on a parser helper.

## Verification

- `cargo check --no-default-features`
- `cargo doc --no-deps`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo deny check`
- `nix build -L .#checks.<system>.ansi-to-tui-{deny,audit}` (local)
